### PR TITLE
Fix forward slash escaping for regex

### DIFF
--- a/.github/labeler.yaml
+++ b/.github/labeler.yaml
@@ -9,13 +9,13 @@ L3:
   - 'L3'  
 
 Python:
-  - python
+  - 'python'
 
 Shell:
-  - shell
+  - 'shell'
 
 C/C++:
-  - C/C++
+  - 'C\/C++'
 
 JS/TS:        
-  - Javascript/Typescript
+  - 'Javascript\/Typescript'


### PR DESCRIPTION
## Overview

I totally missed the escaping for `/` in labeler regex.