### PR TITLE
Fix c++ regex

### DIFF
--- a/.github/labeler.yaml
+++ b/.github/labeler.yaml
@@ -15,7 +15,7 @@ Shell:
   - 'shell'
 
 C/C++:
-  - 'C\/C++'
+  - 'C\/C\+\+'
 
 JS/TS:        
   - 'Javascript\/Typescript'


### PR DESCRIPTION
Escaping the `+` in `C++` for regex... missed this one as well.